### PR TITLE
fix: remove brackets near chmod command

### DIFF
--- a/protonup-qt/index.html
+++ b/protonup-qt/index.html
@@ -117,7 +117,7 @@
 							<ol style="text-align: left;">
 								<li>Download the ProtonUp-Qt AppImage/Flatpak.</li>
 								AppImage only:
-								<li>Mark the AppImage as executable (either using your file manager or using the Terminal: <code>chmod +x ProtonUp-Qt*.AppImage</code>)</li>
+								<li>Mark the AppImage as executable by either using your file manager or using the Terminal: <code>chmod +x ProtonUp-Qt*.AppImage</code></li>
 								<li>Double-click the AppImage to run ProtonUp-Qt</li>
 								<li>(Optional: <a href="https://docs.appimage.org/user-guide/run-appimages.html#integrating-appimages-into-the-desktop">Integrate the AppImage into your desktop</a>. More information about AppImages <a href="https://docs.appimage.org/user-guide/index.html">here</a>)</li>
 							</ol>


### PR DESCRIPTION
Users are supposed to copy-paste this command (since advanced users already know how to do it), and having a closing bracket near the command is annoying for them since you need to be careful not to copy the bracket.